### PR TITLE
Rewrite state machine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set (STATE_MACHINE_NAME "ExoTestMachine")
 #set (STATE_MACHINE_NAME "M2DemoMachine")
 #set (STATE_MACHINE_NAME "M3DemoMachine")
 #set (STATE_MACHINE_NAME "X2DemoMachine")
+#set (STATE_MACHINE_NAME "X2ROS2DemoMachine")
 #set (STATE_MACHINE_NAME "LoggingDevice")
 
 #Use this if your state machine code folder is not in CORC 'src/apps/' folder.
@@ -25,7 +26,10 @@ set (STATE_MACHINE_NAME "ExoTestMachine")
 set(NO_ROBOT ON)
 
 # ROS Flag. set ON if you want to use ROS. Else, set OFF.
+# Also set ROS2 ON if you want to use ROS2. Else, ROS1 by default.
 set(USE_ROS OFF)
+set(ROS2 OFF)
+
 # Select desired logging level (Options: TRACE, DEBUG, INFO, WARN, ERROR, CRITICAL OFF)
 # INFO is the recommended level in normal operation
 set(CORC_LOGGING_LEVEL INFO)
@@ -90,8 +94,8 @@ if(NO_ROBOT)
     add_definitions(-DNOROBOT=1)
 endif()
 
-## Get all source and header files (only the target app folder is included)
-file(GLOB_RECURSE SOURCES "src/core/*.cpp" "src/core/*.c" "src/hardware/*.cpp" "src/hardware/*.c" "${STATE_MACHINE_PATH}/${STATE_MACHINE_NAME}/*.c" "${STATE_MACHINE_PATH}/${STATE_MACHINE_NAME}/*.cpp" "lib/FLNL/src/*.cpp")
+# Get all source and header files (only the target app folder is included)
+file(GLOB_RECURSE SOURCES "src/core/*.cpp" "src/core/*.c" "src/hardware/*.cpp" "src/hardware/*.c" "${STATE_MACHINE_PATH}/${STATE_MACHINE_NAME}/*.c" "${STATE_MACHINE_PATH}/${STATE_MACHINE_NAME}/*.cpp" "lib/spdlog/src/*.cpp" "lib/FLNL/src/*.cpp")
 file(GLOB_RECURSE HEADERS "src/core/*.h" "src/hardware/*.h" "${STATE_MACHINE_PATH}/${STATE_MACHINE_NAME}/*.h" )
 
 ## Set every folder containing .h file as include directory
@@ -109,7 +113,6 @@ list (APPEND INCLUDE_DIRS lib/spdlog/include/)
 
 add_subdirectory(lib/yaml-cpp/)
 
-
 ## Hack for Yaml files path (absolute path required for ROS use, see X2Robot::initializeRobotParams)
 if(CMAKE_CROSSCOMPILING)
     add_definitions(-DBASE_DIRECTORY=.)
@@ -117,65 +120,81 @@ else()
     add_definitions(-DBASE_DIRECTORY=${CMAKE_SOURCE_DIR})
 endif()
 
-## Add ROS 1 dependencies
 if(USE_ROS)
-    #ROS 1 local compile: use catkin
-    message("--catkin--")
-    # Required ROS packages
-    find_package(catkin REQUIRED COMPONENTS
-        roscpp
-        rospy
-        std_msgs
-        std_srvs
-        sensor_msgs
-        geometry_msgs
-        dynamic_reconfigure
-        message_generation
-    )
-    if(SIM)
+    ## Add ROS 1 dependencies
+    if(NOT ROS2)
+
+        #ROS 1 local compile: use catkin
+        message("--catkin--")
+        # Required ROS packages
         find_package(catkin REQUIRED COMPONENTS
-        controller_manager_msgs
-        cob_gazebo_ros_control
-        x2_description
+            roscpp
+            rospy
+            std_msgs
+            std_srvs
+            sensor_msgs
+            geometry_msgs
+            dynamic_reconfigure
+            message_generation
         )
-    endif()
+        if(SIM)
+            find_package(catkin REQUIRED COMPONENTS
+            controller_manager_msgs
+            cob_gazebo_ros_control
+            x2_description
+            )
+        endif()
 
-    generate_dynamic_reconfigure_options(
-            config/m1_dynamic_params.cfg
-            config/x2_dynamic_params.cfg
-    )
+        generate_dynamic_reconfigure_options(
+                config/m1_dynamic_params.cfg
+                config/x2_dynamic_params.cfg
+        )
 
-    add_message_files(
-        FILES
-        X2Array.msg
-        X2Acceleration.msg
-        X2AccelerationMerge.msg
-    )
+        add_message_files(
+            FILES
+            X2Array.msg
+            X2Acceleration.msg
+            X2AccelerationMerge.msg
+        )
 
-    generate_messages(
-       DEPENDENCIES
-       std_msgs
-    )
-
-    catkin_package(
-        #  INCLUDE_DIRS include
-        #  LIBRARIES x2
-        CATKIN_DEPENDS
-        roscpp
-        rospy
+        generate_messages(
+        DEPENDENCIES
         std_msgs
-        std_srvs
-        sensor_msgs
-        geometry_msgs
-        dynamic_reconfigure
-        message_runtime
-        #  DEPENDS system_lib
-    )
+        )
 
-    #include CATKIN
-    include_directories(${catkin_INCLUDE_DIRS})
-    set(ROS_LIBRARIES ${catkin_LIBRARIES})
+        catkin_package(
+            #  INCLUDE_DIRS include
+            #  LIBRARIES x2
+            CATKIN_DEPENDS
+            roscpp
+            rospy
+            std_msgs
+            std_srvs
+            sensor_msgs
+            geometry_msgs
+            dynamic_reconfigure
+            message_runtime
+            #  DEPENDS system_lib
+        )
+
+        #include CATKIN
+        include_directories(${catkin_INCLUDE_DIRS})
+        set(ROS_LIBRARIES ${catkin_LIBRARIES})
+
+    ## Add ROS2 dependencies
+    else()
+
+        #ROS 2 local compile: use colcon
+        message("--colcon--")
+
+        find_package(ament_cmake REQUIRED)
+        find_package(rclcpp REQUIRED)
+        find_package(std_msgs REQUIRED)
+        find_package(sensor_msgs REQUIRED)
+
+    endif()
 endif()
+
 
 
 ## Executable name: {STATEMACHINENAME}_APP
@@ -188,7 +207,7 @@ add_executable(${APP_NAME}
                 )
 
 ## Includes
-target_include_directories(${APP_NAME} PRIVATE ${INCLUDE_DIRS})
+target_include_directories(${APP_NAME} PUBLIC ${INCLUDE_DIRS})
 
 ## Set required external packages
 find_package(Threads REQUIRED)
@@ -200,10 +219,26 @@ target_link_libraries(${APP_NAME}
 
 ## Link ROS libraries
 if(USE_ROS)
-    target_link_libraries(${APP_NAME} ${ROS_LIBRARIES})
+    if(NOT ROS2)
+        target_link_libraries(${APP_NAME} ${ROS_LIBRARIES})
 
-    # make sure configure headers are built before any node using them
-    add_dependencies(${APP_NAME} ${PROJECT_NAME}_gencfg)
+        # make sure configure headers are built before any node using them
+        add_dependencies(${APP_NAME} ${PROJECT_NAME}_gencfg)
+
+    else()
+        include_directories(${INCLUDE_DIRS})
+
+        ament_target_dependencies(${APP_NAME} rclcpp std_msgs sensor_msgs)
+        ament_export_dependencies(rclcpp std_msgs sensor_msgs)
+
+        install(TARGETS ${APP_NAME} DESTINATION lib/${PROJECT_NAME})
+        install(PROGRAMS script/initCAN0.sh DESTINATION lib/${PROJECT_NAME})
+        install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+        install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
+
+        ament_package()
+
+    endif()
 endif()
 
 

--- a/launch/x2_ros2.launch.py
+++ b/launch/x2_ros2.launch.py
@@ -1,0 +1,56 @@
+import os
+
+from xacro import process_file
+from ament_index_python import get_package_share_directory
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+	# Launch description
+	ld = LaunchDescription()
+
+	# Package share path
+	corc_path = get_package_share_directory("CORC")
+	x2_description_path = get_package_share_directory("x2_description")
+
+	# Package share paths
+	exo_path = os.path.join(corc_path, "config", "x2_params.yaml")
+	rviz_path = os.path.join(x2_description_path, "rviz", "x2.rviz")
+
+	# Process XACRO
+	urdf_xacro = process_file(
+		os.path.join(x2_description_path, "urdf", "x2_fixed_base.urdf.xacro")
+	)
+
+	# Nodes
+	exo_node = Node(
+		package="CORC",
+		executable="X2ROS2DemoMachine_APP",
+		arguments=["-can", "can0"],
+		name="x2",
+		output="screen",
+        parameters=[
+			{ "exo_path": exo_path }
+		]
+	)
+	robot_state_node = Node(
+		package="robot_state_publisher",
+		executable="robot_state_publisher",
+		name="robot_state_publisher",
+		parameters=[
+			{ "robot_description": urdf_xacro.toprettyxml(indent='	') }
+		]
+	)
+	rviz_node = Node(
+		package="rviz2",
+		executable="rviz2",
+		arguments=["-d", rviz_path],
+		name="rviz2"
+	)
+
+	# Launch description actions
+	ld.add_action(exo_node)
+	ld.add_action(robot_state_node)
+	ld.add_action(rviz_node)
+	return ld

--- a/package.ros2.xml
+++ b/package.ros2.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>CORC</name>
+  <version>1.0.0</version>
+  <description>The CORC package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="benjaminvonsnarski@gmail.com">Benjamin von Snarski</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>Apache 2</license>
+
+
+  <!-- Url tags are optional, but multiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/x2</url> -->
+
+
+  <!-- Author tags are optional, multiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintainers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
+  <!--   <depend>roscpp</depend> -->
+  <!--   Note that this is equivalent to the following: -->
+  <!--   <build_depend>roscpp</build_depend> -->
+  <!--   <exec_depend>roscpp</exec_depend> -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use build_export_depend for packages you need in order to build against this package: -->
+  <!--   <build_export_depend>message_generation</build_export_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use exec_depend for packages you need at runtime: -->
+  <!--   <exec_depend>message_runtime</exec_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <!-- Use doc_depend for packages you need only for building documentation: -->
+  <!--   <doc_depend>doxygen</doc_depend> -->
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/apps/X2ROS2DemoMachine/X2ROS2DemoMachine.cpp
+++ b/src/apps/X2ROS2DemoMachine/X2ROS2DemoMachine.cpp
@@ -1,0 +1,62 @@
+#include "X2ROS2DemoMachine.h"
+
+X2ROS2DemoMachine::X2ROS2DemoMachine(int argc, char **argv) : StateMachine()
+{
+    // Create and set X2Robot object
+    setRobot(std::make_unique<X2Robot>());
+
+    // Configure ROS2 initialisation options and disable SIGINT capture (handled by CORC)
+    rclcpp::InitOptions ros_init = rclcpp::InitOptions();
+    ros_init.shutdown_on_sigint = false;
+    rclcpp::init(argc, argv, ros_init);
+
+    // Create the ROS2 node and pass a reference to the X2 Robot object
+    m_Node = std::make_shared<X2ROS2Node>("x2", get_robot());
+
+    // Add some state that also holds reference to the ROS2 node
+    addState("state", std::make_shared<X2ROS2State>(get_robot(), get_node()));
+
+    // Set the initial state
+    setInitState("state");
+}
+
+void
+X2ROS2DemoMachine::end()
+{
+    spdlog::info("State machine end");
+}
+
+void
+X2ROS2DemoMachine::init()
+{
+    get_robot()->initialiseNetwork();
+}
+
+void
+X2ROS2DemoMachine::hwStateUpdate()
+{
+    // Update robot parameters
+    get_robot()->updateRobot();
+    // Call custom publish method for publishing joint states of X2 Robot
+    get_node()->publish_joint_states();
+    // Allow for the ROS2 node to execute callbacks (e.g., subscriptions)
+    rclcpp::spin_some(get_node()->get_interface());
+}
+
+bool
+X2ROS2DemoMachine::configureMasterPDOs()
+{
+    return get_robot()->configureMasterPDOs();
+}
+
+X2Robot *
+X2ROS2DemoMachine::get_robot()
+{
+    return static_cast<X2Robot *>(_robot.get());
+}
+
+const std::shared_ptr<X2ROS2Node> &
+X2ROS2DemoMachine::get_node()
+{
+    return m_Node;
+}

--- a/src/apps/X2ROS2DemoMachine/X2ROS2DemoMachine.h
+++ b/src/apps/X2ROS2DemoMachine/X2ROS2DemoMachine.h
@@ -1,0 +1,34 @@
+/**
+ * \file X2ROS2DemoMachine.h
+ * \author Benjamin von Snarski
+ * \version 0.1
+ * \date 2022-10-24
+ * \copyright Copyright (c) 2022
+ * \brief An example CORC state machine implementing the ROS2 client library.
+ */
+#ifndef SRC_X2ROS2DEMOMACHINE_H
+#define SRC_X2ROS2DEMOMACHINE_H
+
+#include "X2Robot.h"
+#include "X2ROS2Node.h"
+#include "X2ROS2State.h"
+#include "StateMachine.h"
+
+class X2ROS2DemoMachine : public StateMachine
+{
+public:
+	X2ROS2DemoMachine(int argc, char **argv);
+
+	void end() override;
+	void init() override;
+	void hwStateUpdate() override;
+	bool configureMasterPDOs() override;
+
+	X2Robot * get_robot();
+	const std::shared_ptr<X2ROS2Node> & get_node();
+
+private:
+	std::shared_ptr<X2ROS2Node> m_Node;
+};
+
+#endif//SRC_X2ROS2DEMOMACHINE_H

--- a/src/apps/X2ROS2DemoMachine/X2ROS2Node.cpp
+++ b/src/apps/X2ROS2DemoMachine/X2ROS2Node.cpp
@@ -1,0 +1,67 @@
+#include "X2ROS2Node.h"
+
+X2ROS2Node::X2ROS2Node(const std::string &name, X2Robot *robot)
+    : Node(name), m_Robot(robot)
+{
+    // Create an example subscription
+    m_Sub = create_subscription<std_msgs::msg::String>(
+        "example_topic", 10, std::bind(&X2ROS2Node::string_callback, this, _1)
+    );
+    // Create a joint state publisher
+    m_Pub = create_publisher<sensor_msgs::msg::JointState>(
+        "joint_states", 10
+    );
+}
+
+rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
+X2ROS2Node::get_interface()
+{
+    // Must have this method to return base interface for spinning
+    return this->get_node_base_interface();
+}
+
+void
+X2ROS2Node::string_callback(const std_msgs::msg::String::SharedPtr msg)
+{
+    // Example callback for subscription
+    spdlog::info("Received ({}) in string callback", msg->data);
+}
+
+void
+X2ROS2Node::publish_joint_states()
+{
+    // Instantiate joint state message
+    sensor_msgs::msg::JointState msg;
+
+    // Assign current header time stamp
+    msg.header.stamp = this->now();
+
+    // Use this naming scheme for robot state publisher to recognise
+    msg.name = {
+        "left_hip_joint",
+        "left_knee_joint",
+        "right_hip_joint",
+        "right_knee_joint",
+        "world_to_backpack"
+    };
+
+    // Copy position, velocity and toroque from X2 Robot
+    msg.position.assign(
+        m_Robot->getPosition().data(),
+        m_Robot->getPosition().data() + m_Robot->getPosition().size()
+    );
+    msg.velocity.assign(
+        m_Robot->getVelocity().data(),
+        m_Robot->getVelocity().data() + m_Robot->getVelocity().size()
+    );
+    msg.effort.assign(
+        m_Robot->getTorque().data(),
+        m_Robot->getTorque().data() + m_Robot->getTorque().size()
+    );
+
+    // Add backpack angle to positions for visualisation (RViz)
+    msg.position.push_back(m_Robot->getBackPackAngleOnMedianPlane() - M_PI_2);
+
+    // Publish the joint state message
+    m_Pub->publish(msg);
+}

--- a/src/apps/X2ROS2DemoMachine/X2ROS2Node.h
+++ b/src/apps/X2ROS2DemoMachine/X2ROS2Node.h
@@ -1,0 +1,37 @@
+/**
+ * \file X2ROS2Node.h
+ * \author Benjamin von Snarski
+ * \version 0.1
+ * \date 2022-10-24
+ * \copyright Copyright (c) 2022
+ * \brief An example ROS2 node that also holds a reference to the robot object.
+ */
+#ifndef SRC_X2ROS2NODE_H
+#define SRC_X2ROS2NODE_H
+
+#include "X2Robot.h"
+
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
+
+using std::placeholders::_1;
+
+class X2ROS2Node : public rclcpp::Node
+{
+public:
+    X2ROS2Node(const std::string &name, X2Robot *robot);
+
+    void string_callback(const std_msgs::msg::String::SharedPtr msg);
+    void publish_joint_states();
+
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr get_interface();
+
+private:
+    X2Robot *m_Robot;
+
+    rclcpp::Subscription<std_msgs::msg::String>::SharedPtr m_Sub;
+    rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr m_Pub;
+};
+
+#endif//SRC_X2ROS2NODE_H

--- a/src/apps/X2ROS2DemoMachine/X2ROS2State.cpp
+++ b/src/apps/X2ROS2DemoMachine/X2ROS2State.cpp
@@ -1,0 +1,23 @@
+#include "X2ROS2State.h"
+
+X2ROS2State::X2ROS2State(X2Robot *robot, const std::shared_ptr<X2ROS2Node> node)
+    : m_Robot(robot), m_Node(node)
+{
+}
+
+void
+X2ROS2State::exit()
+{
+    spdlog::info("Exited X2ROS2State");
+}
+
+void
+X2ROS2State::entry()
+{
+    spdlog::info("Entered X2ROS2State");
+}
+
+void
+X2ROS2State::during()
+{
+}

--- a/src/apps/X2ROS2DemoMachine/X2ROS2State.h
+++ b/src/apps/X2ROS2DemoMachine/X2ROS2State.h
@@ -1,0 +1,31 @@
+/**
+ * \file X2ROS2State.h
+ * \author Benjamin von Snarski
+ * \version 0.1
+ * \date 2022-10-24
+ * \copyright Copyright (c) 2022
+ * \brief An example state that publishes the current X2 robot joint states and subscribes to an example topic.
+ * Also holds reference to the ROS2 node.
+ */
+#ifndef SRC_X2ROS2STATE_H
+#define SRC_X2ROS2STATE_H
+
+#include "State.h"
+#include "X2Robot.h"
+#include "X2ROS2Node.h"
+
+class X2ROS2State : public State
+{
+public:
+    X2ROS2State(X2Robot *robot, const std::shared_ptr<X2ROS2Node> node);
+
+    void exit() override;
+    void entry() override;
+    void during() override;
+
+private:
+    X2Robot *m_Robot;
+    const std::shared_ptr<X2ROS2Node> m_Node;
+};
+
+#endif//SRC_X2ROS2STATE_H


### PR DESCRIPTION
Outstanding issues:

1. In line 98 of the cmake file, the source file `lib/spdlog/src/*.cpp` seems to be needed when compiling for `X2ROS2DemoMachine`, however, does not compile when added for `X2DemoMachine` (ROS1). We could either investigate this case or make it a conditional flag.

2. Although seemingly unrelated to the ROS2 implementation, the `X2DemoMachine` app seems to have two issues. 1) It does not compile as it is missing a body for the `X2DemoState::exit()` method; and 2) It produces the following warnings during run-time: `[2022-11-10 11:49:27.400] [CORC] [warning] Applicaton thread time overflow: 2.748ms (>2.0ms) !`

The ROS2 implementation works as intended, with the following functionality:

- Publishes to `/joint_state` so that it may be used in conjunction with RViz.
- Subscribes to an example topic that prints the string from the CORC app.